### PR TITLE
Fix: form 제출 후 quantity 로 auto focus 되던 문제

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,9 @@ const GlobalStyle = createGlobalStyle`
     border:none;
     cursor: pointer;
   }
+  body{
+    height:100vh;
+  }
 `;
 
 function App() {

--- a/src/components/CreateItems.tsx
+++ b/src/components/CreateItems.tsx
@@ -60,7 +60,6 @@ function CreateItems() {
     setError,
     clearErrors,
     formState: { errors },
-    setFocus,
     setValue,
   } = useForm<IForm>();
   const handleValid = ({ quantity, width, height }: IForm) => {
@@ -83,7 +82,6 @@ function CreateItems() {
     setValue("quantity", "");
     setValue("width", "");
     setValue("height", "");
-    setFocus("quantity");
   };
   return (
     <>

--- a/src/components/Item.tsx
+++ b/src/components/Item.tsx
@@ -17,6 +17,7 @@ const InfoContainer = styled.div`
   padding: 5px 10px;
   display: flex;
   justify-content: space-between;
+  align-items: center;
   button {
     border-radius: 5px;
     transition: all 0.2s ease-out;
@@ -41,6 +42,9 @@ const InfoContainer = styled.div`
         &:not(&:nth-child(2)) {
           font-size: 15px;
           padding: 5px;
+        }
+        &:last-child {
+          vertical-align: middle;
         }
       }
     }

--- a/src/components/ItemList.tsx
+++ b/src/components/ItemList.tsx
@@ -20,6 +20,7 @@ const Title = styled.h1`
 
 const List = styled.ul`
   margin-top: 10px;
+  padding-bottom: 50px;
 `;
 
 function ItemList() {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,0 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';


### PR DESCRIPTION
react-hook-form 에서 setFocus 기능 제거
하단 totalPrice 컴포넌트에 item 가려짐 해결

closes #6 